### PR TITLE
Add some embedded HTML for get.submariner.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,13 @@
 #<HTML><HEAD><style>body {background-color: cyan;}</style></HEAD><BODY><!--
 #--> <p><img width="500" src="https://submariner.io/images/logo-submariner.svg" /> </p> <!--
 #--> <H1> Hi! I'm the get.submariner.io script</H1> <!--
-#--> I'm served from GitHub pages and my source code lives here: <!--
-#-->   <a href="https://github.com/submariner-io/get.submariner.io">get.submariner.io @ github.com</a> <!--
-#--> You can find some useful links here: <!--
+#--> <p>I'm served from GitHub pages and my source code lives here: <!--
+#-->   <a href="https://github.com/submariner-io/get.submariner.io">get.submariner.io @ github.com</a></p> <!--
+#--> <p>You can find some useful links here: <!--
 #--> <ul><li> <a href="https://submariner.io/quickstart/kind/#install-subctl">A quickstart on installing submariner</a> </li> <!--
 #-->     <li> <a href="https://submariner.io/">The Submariner website</a> </li><!--
 #-->     <li> <a href="https://submariner.io/contributing/">References to our slack channel and contribution guidelines</a> </li><!--
-#--> </ul> <!--
+#--> </ul></p> <!--
 #--> <h2>Source code:</h2> <pre>
 set -e
 

--- a/index.html
+++ b/index.html
@@ -1,4 +1,15 @@
 #!/bin/bash
+#<HTML><HEAD><style>body {background-color: cyan;}</style></HEAD><BODY><!--
+#--> <p><img width="500" src="https://submariner.io/images/logo-submariner.svg" /> </p> <!--
+#--> <H1> Hi! I'm the get.submariner.io script</H1> <!--
+#--> I'm served from GitHub pages and my source code lives here: <!--
+#-->   <a href="https://github.com/submariner-io/get.submariner.io">get.submariner.io @ github.com</a> <!--
+#--> You can find some useful links here: <!--
+#--> <ul><li> <a href="https://submariner.io/quickstart/kind/#install-subctl">A quickstart on installing submariner</a> </li> <!--
+#-->     <li> <a href="https://submariner.io/">The Submariner website</a> </li><!--
+#-->     <li> <a href="https://submariner.io/contributing/">References to our slack channel and contribution guidelines</a> </li><!--
+#--> </ul> <!--
+#--> <h2>Source code:</h2> <pre>
 set -e
 
 get_operating_system() {
@@ -124,3 +135,5 @@ echo "Downloading..."
 trap finish_cleanup EXIT
 
 get_subctl
+
+#</pre><BODY></HTML>


### PR DESCRIPTION
This adds some HTML in the script, so in case someone
visits get.submariner.io from a browser something
meaningful will be displayed.

It's not perfect, and still it's not valid HTML because
of the initial bash header, but, it's ok for browsers

![image](https://user-images.githubusercontent.com/1176434/94272616-8fe0fd80-ff43-11ea-9cd7-2a1bff3fee0b.png)


Signed-off-by: Miguel Angel Ajo <majopela@redhat.com>