### PR TITLE
fix: replace the install command to support mac osx

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,7 +110,9 @@ install_subctl() {
   local destdir=${DESTDIR:-~/.local/bin}
   local dest=${destdir}/subctl
 
-  install -D "${bin}" "${dest}"
+  mkdir -p "$destdir"
+  cp -f "${bin}" "${dest}"
+  chmod +x "${dest}"
 
   bin_file=$(basename "${bin}")
   echo "${bin_file} has been installed as ${dest}"


### PR DESCRIPTION
The flag -D is not supported by mac osx.
Use mkdir cp and chmod instead of install command.

Closes submariner-io/submariner-operator#790
Signed-off-by: Steve Mattar <smattar@redhat.com>