### PR TITLE
Use SHAs for GHA versions

### DIFF
--- a/.github/workflows/version_handling.yml
+++ b/.github/workflows/version_handling.yml
@@ -14,7 +14,7 @@ jobs:
         version: ['v0.5.0', 'v0.6.0', 'v0.7.0', 'v0.8.0', 'rc', 'latest', 'devel', 'release-0.8']
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Download and install subctl
         run: VERSION="${{ matrix.version }}" ./getsubctl.sh


### PR DESCRIPTION
Per GitHub's security guidelines, GHAs should be pinned using full
length commit SHAs instead of tags.

The SHAs are of the commits currently resolved by the versions.

Even "trusted" GHAs from GitHub developers are pinned because it's
possible their repo rights could be compromised and a malicious GHA
published. These core repos are not frequently substantially updated.

Submariner-internal GHAs are left pinned at devel because we want
automatic updates from Shipyard's shared tooling.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>