### PR TITLE
Delete the target instead of replacing it

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,11 @@ install_subctl() {
   local dest=${destdir}/subctl
 
   mkdir -p "$destdir"
-  cp -f "${bin}" "${dest}"
+  
+  # Delete the target if it exists, to ensure we get a new inode
+  # This allows a running subctl to be replace (e.g. if subctl is really a download script)
+  rm -f "${dest}"
+  cp "${bin}" "${dest}"
   chmod +x "${dest}"
 
   bin_file=$(basename "${bin}")


### PR DESCRIPTION
In some circumstances, we may want to replace a running subctl,
e.g. if the running "subctl" is really a download script (see
https://github.com/submariner-io/shipyard/pull/893 for the scenario
which prompted this).

cp -f only deletes the target if it can't be written. Instead, remove
the target explicitly, using rm -f so we don't fail if it doesn't
exist. This ensures that the old inode is preserved if it is still in
use, and the new file doesn't replace an old one which is still
needed.

On platforms with GNU cp, cp --remove-destination could be used
instead, but getsubctl.sh should work on non-GNU platforms too.

Signed-off-by: Stephen Kitt <skitt@redhat.com>