### PR TITLE
Minimize GHA permissions

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -4,6 +4,8 @@ name: Branch Checks
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   target_branch:
     name: PR targets branch

--- a/.github/workflows/version_handling.yml
+++ b/.github/workflows/version_handling.yml
@@ -4,6 +4,8 @@ name: Version-handling check
 on:
   pull_request:
 
+permissions: {}
+
 jobs:
   versions:
     name: Versions


### PR DESCRIPTION
Set the GitHub Actions token permission to null in all workflows.

This results in:

GITHUB_TOKEN Permissions
  Metadata: read

The default permissions, used without the null override, are either

GITHUB_TOKEN Permissions
  Actions: write
  Checks: write
  Contents: write
  Deployments: write
  Discussions: write
  Issues: write
  Metadata: read
  Packages: write
  Pages: write
  PullRequests: write
  RepositoryProjects: write
  SecurityEvents: write
  Statuses: write

or

GITHUB_TOKEN Permissions
  Actions: read
  Checks: read
  Contents: read
  Deployments: read
  Discussions: read
  Issues: read
  Metadata: read
  Packages: read
  Pages: read
  PullRequests: read
  RepositoryProjects: read
  SecurityEvents: read
  Statuses: read

Jobs triggered by PRs get read permissions, other jobs get write.

No jobs in this repo require non-null permissions to function.

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>