### PR TITLE
Use shell arithmetic instead of bc

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ get_subctl() {
 
     [ "$i" == 5 ] && exit 1
     sleep "${backoff}"
-    backoff=$(bc <<< $backoff*1.5)
+    backoff=$((backoff * 2))
   done
 }
 


### PR DESCRIPTION
bc is no longer installed by default in some environments. We can back off by factors of 2 instead of 1.5, and use shell arithmetic instead of relying on bc.

Signed-off-by: Stephen Kitt <skitt@redhat.com>