### PR TITLE
Add target to install tip of latest release branch

### DIFF
--- a/.github/workflows/version_handling.yml
+++ b/.github/workflows/version_handling.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ['v0.7.0', 'v0.8.0', 'v0.12.0', 'rc', 'latest', 'devel', 'release-0.8', 'release-0.12']
+        version: ['v0.7.0', 'v0.8.0', 'v0.12.0', 'rc', 'latest', 'tip-latest-release', 'devel', 'release-0.8', 'release-0.12']
     steps:
       - name: Check out the repository
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ get=$(download_command)
 
 sanitized_version() {
   case $1 in
-    rc|latest|devel|release*|feature*|v*) echo $1;;
+    rc|latest|tip-latest-release|devel|release*|feature*|v*) echo $1;;
     *) echo "v$1" ;;
   esac
 }
@@ -69,6 +69,7 @@ get_subctl_release_url() {
            draft_filter="grep \-rc"
            ;;
     latest) url=https://api.github.com/repos/submariner-io/releases/releases/latest ;;
+    tip-latest-release) url=https://api.github.com/repos/submariner-io/subctl/releases ;;
     feature-multi-active-gw|release-0.?|release-0.1[012])
         echo "https://github.com/submariner-io/submariner-operator/releases/download/subctl-${VERSION}/subctl-${VERSION}-${os}-${architecture}.tar.xz"
         return


### PR DESCRIPTION
This could be used to enable additional upgrade testing without having to maintain a hard-coded tracker for the last release in CI.

It could also replace our current use of the `latest` target in CI, to allow fixes to release branches to fix upgrade CI without having to disable upgrade jobs. Example of needing this:

https://github.com/submariner-io/lighthouse/pull/736#issuecomment-1111213026

Fixes: #23
Relates-to: submariner-io/submariner#2369