### PR TITLE
Add CODEOWNERS configuration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+* @Oats87 @skitt @sridhargaddam @tpantelis
+*.md @dfarrell07 @Oats87 @skitt @sridhargaddam @tpantelis
+/.github/workflows/ @mkolesnik @Oats87 @skitt @sridhargaddam @tpantelis


### PR DESCRIPTION
Copy the standard owners configured across Submariner.

Also causes reviewers to be automatically added to PRs.

Fixes: #25