### PR TITLE
Update the binary path

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ download_and_install() {
     *tar.xz)
       ${get} "${url}" | tar xfJ - || return 1
       # shellcheck disable=SC2086
-      install_subctl subctl*/subctl*${os}-${architecture}*
+      install_subctl subctl*/subctl*
       ;;
     *) # non tar.xz releases (older)
       filename=$(basename "${url}")


### PR DESCRIPTION
in accordance with https://github.com/submariner-io/subctl/pull/837 changing the `subctl` binary location.

Epic: https://github.com/submariner-io/enhancements/issues/182