### PR TITLE
Fix arch detection of Linux/aarch64

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,9 +31,10 @@ get_architecture() {
     x86_64) echo "amd64" ;;
     amd64) echo "amd64" ;;
     arm64) echo "arm64" ;;
+    aarch64) echo "arm64" ;;
     i?86) echo "386" ;;
     *)
-    error "This installer only supports x86_64, i386, amd64 and arm64 architectures. Found $(uname -m)"
+    error "This installer only supports x86_64, i386, amd64, arm64, and aarch64 architectures. Found $(uname -m)"
     return 1;;
   esac
 }


### PR DESCRIPTION
Fix arch detection on Linux/aarch64 (e.g. Asahi Linux on MacBook M*). From Go point of view, this is arm64.

    $ uname -m
    aarch64

    $ go env GOOS
    linux

    $ go env GOARCH
    arm64

Tested by running directly from source.

Fixes #58